### PR TITLE
[FEAT] expect.empty()

### DIFF
--- a/transforms/mocha-to-qunit/__testfixtures__/basic.input.js
+++ b/transforms/mocha-to-qunit/__testfixtures__/basic.input.js
@@ -18,9 +18,12 @@ describe('Integration | Component', function() {
     expect(false).to.be.false;
     expect(false, 'expect with message').to.be.false;
 
-    // Negative cases with variance
-    expect(result).to.be.empty;
-    expect(result, 'With Message').to.be.empty;
+    // Empty checks
+    expect('', 'empty string').to.be.empty;
+    expect([], 'empty array').to.be.empty;
+    expect({}, 'empty object').to.be.empty;
+    expect([1, 2], 'non empty array').to.not.be.empty;
+    expect({"name": "freshworks"}, 'non empty object').to.not.be.empty;
 
     // Variations in equal assertion
     expect(true).to.equal(true);

--- a/transforms/mocha-to-qunit/__testfixtures__/basic.output.js
+++ b/transforms/mocha-to-qunit/__testfixtures__/basic.output.js
@@ -20,9 +20,12 @@ module('Integration | Component', function(hooks) {
     assert.equal(false, false);
     assert.equal(false, false, 'expect with message');
 
-    // Negative cases with variance
-    assert.notOk(result);
-    assert.notOk(result, 'With Message');
+    // Empty checks
+    assert.notOk('', 'empty string');
+    assert.notOk(Array.from([]).length, 'empty array');
+    assert.notOk(Object.keys({}).length, 'empty object');
+    assert.ok(Array.from([1, 2]).length, 'non empty array');
+    assert.ok(Object.keys({"name": "freshworks"}).length, 'non empty object');
 
     // Variations in equal assertion
     assert.equal(true, true);


### PR DESCRIPTION
**CHAI:**

- When the target is a string or array, .empty asserts that the target’s length property is strictly (===) equal to 0.
- When the target is a map or set, .empty asserts that the target’s size property is strictly equal to 0.
- When the target is a non-function object, .empty asserts that the target doesn’t have any own enumerable properties. Properties with Symbol-based keys are excluded from the count.

**QUNIT ASSERT:**

assert.ok & assert.notOk checks for truthy/falsy values and hence can be used with appropriate transformations. 
[qunit/assert.js](https://github.com/qunitjs/qunit/blob/e6787290d6bae6b4332e985d0ac035f4bce9b21d/src/assert.js#L163)