### PR TITLE
Fix group store operations issue

### DIFF
--- a/transforms/async-leaks/__testfixtures__/basic.input.js
+++ b/transforms/async-leaks/__testfixtures__/basic.input.js
@@ -5,17 +5,18 @@ describe('Integration | Component | app-components/from-email', function() {
   
   hooks.beforeEach(function() {
     this.store = this.owner.lookup('service:store');
-    this.get('store').createRecord('contact', contact);
+    this.get('store').createRecord('contact', contact); // comments
+    let a = 1;
     this.get('store').createRecord('ticket', ticket);
+    this.get('store').createRecord('agent', agent);
   });
 
-  it('should add run loop', async function() {
+  it('should add run loop', function() {
     get(this, 'store').findAll('tickets');
     server.createList('email-config', 20);
     server.create('email-config', { name: 'Test', reply_email: 'test@gmail.com' });
-
-    get(this, 'store').pushPayload('contact', { contact: agentContact.attrs  });
-    get(this, 'store').pushPayload('contact', { contact: userContact.attrs  });
+    get(this, 'store').pushPayload('contact', { contact: userContact.attrs });
+    get(this, 'store').findAll('agents');
   });
 
   it('should ignore existing run loop', async function() {

--- a/transforms/async-leaks/__testfixtures__/basic.input.js
+++ b/transforms/async-leaks/__testfixtures__/basic.input.js
@@ -6,9 +6,11 @@ describe('Integration | Component | app-components/from-email', function() {
   hooks.beforeEach(function() {
     this.store = this.owner.lookup('service:store');
     this.get('store').createRecord('contact', contact);
+    this.get('store').createRecord('ticket', ticket);
   });
 
   it('should add run loop', async function() {
+    get(this, 'store').findAll('tickets');
     server.createList('email-config', 20);
     server.create('email-config', { name: 'Test', reply_email: 'test@gmail.com' });
 

--- a/transforms/async-leaks/__testfixtures__/basic.output.js
+++ b/transforms/async-leaks/__testfixtures__/basic.output.js
@@ -5,12 +5,18 @@ describe('Integration | Component | app-components/from-email', function() {
   
   hooks.beforeEach(function() {
     this.store = this.owner.lookup('service:store');
+
     run(() => {
       this.get('store').createRecord('contact', contact);
+      this.get('store').createRecord('ticket', ticket);
     });
   });
 
   it('should add run loop', async function() {
+    run(() => {
+      get(this, 'store').findAll('tickets');
+    });
+
     server.createList('email-config', 20);
     server.create('email-config', { name: 'Test', reply_email: 'test@gmail.com' });
 

--- a/transforms/async-leaks/__testfixtures__/basic.output.js
+++ b/transforms/async-leaks/__testfixtures__/basic.output.js
@@ -5,24 +5,25 @@ describe('Integration | Component | app-components/from-email', function() {
   
   hooks.beforeEach(function() {
     this.store = this.owner.lookup('service:store');
-
     run(() => {
-      this.get('store').createRecord('contact', contact);
+      this.get('store').createRecord('contact', contact); // comments
+    });
+    let a = 1;
+    run(() => {
       this.get('store').createRecord('ticket', ticket);
+      this.get('store').createRecord('agent', agent);
     });
   });
 
-  it('should add run loop', async function() {
+  it('should add run loop', function() {
     run(() => {
       get(this, 'store').findAll('tickets');
     });
-
     server.createList('email-config', 20);
     server.create('email-config', { name: 'Test', reply_email: 'test@gmail.com' });
-
     run(() => {
-      get(this, 'store').pushPayload('contact', { contact: agentContact.attrs  });
-      get(this, 'store').pushPayload('contact', { contact: userContact.attrs  });
+      get(this, 'store').pushPayload('contact', { contact: userContact.attrs });
+      get(this, 'store').findAll('agents');
     });
   });
 

--- a/transforms/async-leaks/__testfixtures__/import.output.js
+++ b/transforms/async-leaks/__testfixtures__/import.output.js
@@ -1,6 +1,6 @@
 import { describe } from 'mocha';
 
-import { run } from "@ember/runloop";
+import { run } from '@ember/runloop';
 
 describe('Integration | Component | app-components/from-email', function() {
   

--- a/transforms/async-leaks/index.js
+++ b/transforms/async-leaks/index.js
@@ -5,95 +5,146 @@ const beautifyImports = require("../beautify-imports");
 module.exports = function transformer(file, api) {
   const j = getParser(api);
   const options = getOptions();
-  const root = j(file.source);
+  const firstRoot = j(file.source);
   const lineTerminator = file.source.indexOf('\r\n') > -1 ? '\r\n' : '\n';
   let isModified = false;
-  let groupedNodes;
-  const importRun = root.find(j.ImportDeclaration, {
+  const importRun = firstRoot.find(j.ImportDeclaration, {
     source: {
       value: "@ember/runloop"
     }
   });
   const isImportExists = importRun && importRun.length > 0;
 
-  const blocks = root.find(j.BlockStatement).filter((path) => {
-    return ['it', 'after', 'before', 'afterEach', 'beforeEach']
-      .includes(path.parent.parent.value.callee.name || path.parent.parent.value.callee.property.name)
-  });
-
-  blocks.forEach((block) => {
-    groupedNodes = [];
-    const leakingExpression = j(block)
-      .find(j.CallExpression)
-      .filter(path => {
-        return (
-          path.node.arguments.length &&
-          path.node.arguments.some(n => n.value == "store")
-        );
-      })
-      .closest(j.ExpressionStatement)
-      .filter(path => {
-        // check for existing run loop
-        return path.parent.parent.parent.node.callee && path.parent.parent.parent.node.callee.name != "run";
-      });
-
-    // GROUP ADJACENT
-    const groupedExp = leakingExpression
-      .filter((nodePath, index, exp) => {
-        const currentNode = nodePath.value;
-        const prevNode = exp[index - 1] ? exp[index - 1].value : null;
-        const nextNode = exp[index + 1] ? exp[index + 1].value : null;
-        return (currentNode.start == (prevNode && prevNode.end + 5) || currentNode.end + 5 == (nextNode && nextNode.start));
-      });
-
-    groupedExp.length && groupedExp.forEach(nodePath => {
-      const { node } = nodePath;
-      groupedNodes.push(node);
-      isModified = true;
-    });
-
-    const newNodes = j.expressionStatement(
-      j.callExpression(j.identifier("run"), [j.arrowFunctionExpression([], j.blockStatement([...groupedNodes]))])
-    );
-    groupedExp.remove();
-    groupedExp && groupedNodes.length && groupedExp.get().insertAfter(newNodes);
-
-    // FILTER SOLO
-    const soloExp = leakingExpression
-      .filter((nodePath, index, exp) => {
-        const currentNode = nodePath.value;
-        const prevNode = exp[index - 1] ? exp[index - 1].value : null;
-        const nextNode = exp[index + 1] ? exp[index + 1].value : null;
-        return (currentNode && !(currentNode.start == (prevNode && prevNode.end + 5) || currentNode.end + 5 == (nextNode && nextNode.start)));
-      });
-
-    soloExp.length && soloExp.replaceWith(nodePath => {
-      const { node } = nodePath;
-      // wrap with run
-      const newNode = j.expressionStatement(
-        j.callExpression(j.identifier("run"), [
-          j.arrowFunctionExpression([], j.blockStatement([node]))
-        ])
+  const storeExpressionsNotInRunLoop = firstRoot
+    .find(j.CallExpression)
+    .filter(path => {
+      return (
+        path.node.arguments.length &&
+        path.node.arguments.some(n => n.value == "store")
       );
-      isModified = true;
-      return newNode;
+    })
+    .closest(j.ExpressionStatement)
+    .filter(path => {
+      // check for existing run loop
+      return (path.parent.parent.parent.node.callee && !["run", "describe"].includes(path.parent.parent.parent.node.callee.name));
     });
 
+  storeExpressionsNotInRunLoop.length && storeExpressionsNotInRunLoop.replaceWith(nodePath => {
+    const { node } = nodePath;
+    // wrap with run
+    const newNode = j.expressionStatement(
+      j.callExpression(j.identifier("run"), [
+        j.arrowFunctionExpression([], j.blockStatement([node]))
+      ])
+    );
+    isModified = true;
+    return newNode;
   });
+
+  const storeDeclarationsNotInRunLoop = firstRoot
+    .find(j.CallExpression)
+    .filter(path => {
+      return (
+        path.node.arguments.length &&
+        path.node.arguments.some(n => n.value == "store")
+      );
+    })
+    .closest(j.VariableDeclaration)
+    .filter(path => {
+      // check for existing run loop    
+      return (path.parent.parent.parent.node.callee && !["run", "describe"].includes(path.parent.parent.parent.node.callee.name));
+    });;
+
+  storeDeclarationsNotInRunLoop.length && storeDeclarationsNotInRunLoop.replaceWith(nodePath => {
+    const { node } = nodePath;
+    const newNode = j.expressionStatement(
+      j.callExpression(j.identifier("run"), [
+        j.arrowFunctionExpression([], j.blockStatement([node]))
+      ])
+    );
+    return newNode;
+  });
+
+  // From this phase we will be combining consecutive 
+  // sequential run loops while maintaining their order
+  let secondRoot = j(firstRoot.toSource());
+
+  let blocksHavingRunLoopExpressions = secondRoot.find(j.CallExpression, {
+    callee: {
+      name: "run"
+    }
+  }).closest(j.BlockStatement);
+
+  blocksHavingRunLoopExpressions.forEach((nodePath) => {
+    let { node } = nodePath;
+    // Below array stores information about where an expression 
+    // is a run loop expression or not, for all expressions inside a block
+    let exArr = []
+
+    node.body.forEach((statement) => {
+      if (statement.expression &&
+        statement.expression.callee &&
+        statement.expression.callee.name === 'run') {
+        exArr.push(true);
+      } else {
+        exArr.push(false);
+      }
+    });
+
+    let batcher = [];
+    exArr.forEach(function (bool, index) {
+      if (bool) {
+        batcher.push(index);
+      } else {
+        transform();
+      }
+    });
+    transform();
+    function transform() {
+      if (batcher.length > 1) {
+        let cNodes = batcher.map((key, index) => {
+          return node.body[key];
+        })
+
+        let mainBlock = cNodes[0].expression.arguments[0].body;
+
+        let newNodes = [...mainBlock.body];
+        cNodes.forEach((currentNode, index) => {
+          if (index !== 0) {
+            newNodes.push(...currentNode.expression.arguments[0].body.body);
+          }
+        });
+
+        mainBlock.body = newNodes;
+
+        batcher.forEach((key, index) => {
+          if (index !== 0) {
+            delete node.body[key];
+          }
+        })
+        isModified = true;
+      }
+      batcher = [];
+    }
+
+    return node;
+  });
+
+
 
   if (isModified && !isImportExists) {
     const importStatement = j.importDeclaration(
       [j.importSpecifier(j.identifier("run"), j.identifier("run"))],
       j.literal("@ember/runloop")
     );
-    root
+    secondRoot
       .find(j.ImportDeclaration)
       .get()
       .insertAfter(importStatement);
   }
 
   return beautifyImports(
-    root.toSource({
+    secondRoot.toSource({
       quote: 'single',
       lineTerminator,
       trailingComma: false

--- a/transforms/async-leaks/index.js
+++ b/transforms/async-leaks/index.js
@@ -1,10 +1,12 @@
 const { getParser } = require("codemod-cli").jscodeshift;
 const { getOptions } = require("codemod-cli");
+const beautifyImports = require("../beautify-imports");
 
 module.exports = function transformer(file, api) {
   const j = getParser(api);
   const options = getOptions();
   const root = j(file.source);
+  const lineTerminator = file.source.indexOf('\r\n') > -1 ? '\r\n' : '\n';
   let isModified = false;
   let groupedNodes;
   const importRun = root.find(j.ImportDeclaration, {
@@ -90,5 +92,11 @@ module.exports = function transformer(file, api) {
       .insertAfter(importStatement);
   }
 
-  return root.toSource();
+  return beautifyImports(
+    root.toSource({
+      quote: 'single',
+      lineTerminator,
+      trailingComma: false
+    })
+  );
 };

--- a/transforms/async-leaks/index.js
+++ b/transforms/async-leaks/index.js
@@ -6,7 +6,7 @@ module.exports = function transformer(file, api) {
   const options = getOptions();
   const root = j(file.source);
   let isModified = false;
-  let groupedNodes = [];
+  let groupedNodes;
   const importRun = root.find(j.ImportDeclaration, {
     source: {
       value: "@ember/runloop"
@@ -14,59 +14,69 @@ module.exports = function transformer(file, api) {
   });
   const isImportExists = importRun && importRun.length > 0;
 
-  const leakingExpression = root
-    .find(j.CallExpression)
-    .filter(path => {
-      return (
-        path.node.arguments.length &&
-        path.node.arguments.some(n => n.value == "store")
-      );
-    })
-    .closest(j.ExpressionStatement)
-    .filter(path => {
-      // check for existing run loop
-      return path.parent.parent.parent.node.callee && path.parent.parent.parent.node.callee.name != "run";
-    });
-  
-  // GROUP ADJACENT
-  const groupedExp = leakingExpression
-  	.filter((nodePath, index, exp) => {
-      const { node } = nodePath.parent;
-      const prevNode = exp[index-1] ? exp[index-1].parent.node : null;
-      const nextNode = exp[index+1] ? exp[index+1].parent.node : null;
-      return (node.start == (prevNode && prevNode.start) || node.start == (nextNode && nextNode.start));
-    });
-    
-  groupedExp.length && groupedExp.forEach(nodePath => {
+  const blocks = root.find(j.BlockStatement).filter((path) => {
+    return ['it', 'after', 'before', 'afterEach', 'beforeEach']
+      .includes(path.parent.parent.value.callee.name || path.parent.parent.value.callee.property.name)
+  });
+
+  blocks.forEach((block) => {
+    groupedNodes = [];
+    const leakingExpression = j(block)
+      .find(j.CallExpression)
+      .filter(path => {
+        return (
+          path.node.arguments.length &&
+          path.node.arguments.some(n => n.value == "store")
+        );
+      })
+      .closest(j.ExpressionStatement)
+      .filter(path => {
+        // check for existing run loop
+        return path.parent.parent.parent.node.callee && path.parent.parent.parent.node.callee.name != "run";
+      });
+
+    // GROUP ADJACENT
+    const groupedExp = leakingExpression
+      .filter((nodePath, index, exp) => {
+        const currentNode = nodePath.value;
+        const prevNode = exp[index - 1] ? exp[index - 1].value : null;
+        const nextNode = exp[index + 1] ? exp[index + 1].value : null;
+        return (currentNode.start == (prevNode && prevNode.end + 5) || currentNode.end + 5 == (nextNode && nextNode.start));
+      });
+
+    groupedExp.length && groupedExp.forEach(nodePath => {
       const { node } = nodePath;
       groupedNodes.push(node);
-    });
-  
-  const newNodes = j.expressionStatement(
-    j.callExpression(j.identifier("run"), [j.arrowFunctionExpression([], j.blockStatement([...groupedNodes]))])
-  );
-  groupedExp.remove();
-  groupedExp && groupedNodes.length && groupedExp.get().insertAfter(newNodes);
-  
-  // FILTER SOLO
-  const soloExp = leakingExpression
-  	.filter((nodePath, index, exp) => {
-      const { node } = nodePath.parent;
-      const prevNode = exp[index-1] ? exp[index-1].parent.node : null;
-      const nextNode = exp[index+1] ? exp[index+1].parent.node : null;
-      return !(node.start == (prevNode && prevNode.start) || node.start == (nextNode && nextNode.start));
+      isModified = true;
     });
 
-  soloExp.length && soloExp.replaceWith(nodePath => {
-    const { node } = nodePath;
-    // wrap with run
-    const newNode = j.expressionStatement(
-      j.callExpression(j.identifier("run"), [
-        j.arrowFunctionExpression([], j.blockStatement([node]))
-      ])
+    const newNodes = j.expressionStatement(
+      j.callExpression(j.identifier("run"), [j.arrowFunctionExpression([], j.blockStatement([...groupedNodes]))])
     );
-    isModified = true;
-    return newNode;
+    groupedExp.remove();
+    groupedExp && groupedNodes.length && groupedExp.get().insertAfter(newNodes);
+
+    // FILTER SOLO
+    const soloExp = leakingExpression
+      .filter((nodePath, index, exp) => {
+        const currentNode = nodePath.value;
+        const prevNode = exp[index - 1] ? exp[index - 1].value : null;
+        const nextNode = exp[index + 1] ? exp[index + 1].value : null;
+        return (currentNode && !(currentNode.start == (prevNode && prevNode.end + 5) || currentNode.end + 5 == (nextNode && nextNode.start)));
+      });
+
+    soloExp.length && soloExp.replaceWith(nodePath => {
+      const { node } = nodePath;
+      // wrap with run
+      const newNode = j.expressionStatement(
+        j.callExpression(j.identifier("run"), [
+          j.arrowFunctionExpression([], j.blockStatement([node]))
+        ])
+      );
+      isModified = true;
+      return newNode;
+    });
+
   });
 
   if (isModified && !isImportExists) {


### PR DESCRIPTION
While grouping consecutive store operations inside a run loop, operation belonging to different “it” or “beforeEach” blocks where grouped in a single block and order of these store operations are preserved.